### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/plugins/locale.server.ts
+++ b/plugins/locale.server.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, useState } from '#app'
+import { defineNuxtPlugin, useState } from '#imports'
 
 export default defineNuxtPlugin((nuxt) => {
 	const locale = useState('locale', () => nuxt.ssrContext.req.headers['accept-language']?.split(',')[0])


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.